### PR TITLE
[Feature] Added ceph_pg_query module

### DIFF
--- a/modules/ceph_pg_query.py
+++ b/modules/ceph_pg_query.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import sys
+import simplejson as json
+import argparse
+
+""" Provide command line arguments """
+parser = argparse.ArgumentParser(description='Query a specific pgid and print \
+                                 the pg_stats from a given ceph-report. \
+                                 Intended to provide similar functionality to \
+                                 the ceph pg query command.')
+parser.add_argument("--id",
+                    dest="pgid",
+                    required=True,
+                    help="Specify a pgid to query from piped in ceph-report.")
+
+args = parser.parse_args()
+
+""" Print the pg_stats for the specific that is being queried """
+# Load in ceph-report json from stdin
+obj=json.load(sys.stdin)

--- a/modules/ceph_pg_query.py
+++ b/modules/ceph_pg_query.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import sys
-import simplejson as json
+import json
 import argparse
 
 """ Provide command line arguments """
@@ -16,6 +16,12 @@ parser.add_argument("--id",
 
 args = parser.parse_args()
 
-""" Print the pg_stats for the specific that is being queried """
+""" Print the pg_stats for the specific pgid that is being queried """
 # Load in ceph-report json from stdin
-obj=json.load(sys.stdin)
+obj = json.load(sys.stdin)
+
+# Match the specified pgid with one from the ceph-report and print that portion
+# of JSON only
+for item in obj['pgmap']['pg_stats']:
+    if item['pgid'] == str(args.pgid):
+        print json.dumps(item, indent=4, sort_keys=True)

--- a/modules/ceph_pg_query.py
+++ b/modules/ceph_pg_query.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import sys
-import json
+import simplejson as json
 import argparse
 
 """ Provide command line arguments """


### PR DESCRIPTION
The `ceph_pg_query` module allows users to utilize similar functionality to the `ceph pg query` command found within Ceph.  This module accepts output from `sys.stdin` like the other modules.  To use just specify a pgid with the `--id` flag: 
~~~
cat ceph-report.json | ./ceph_pg_query.py --id <pgid> 
~~~

Due to the nature of python and the fact that `json.load()` is loading the JSON in as a dict the keys of the ceph-report have to be resorted and thusly the the sorting of the ceph-report is not preserved. 